### PR TITLE
Fix issue-7 sorting problem root cause: incorrect isNumber() impl

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 export const _isArray = arr => Array.isArray(arr)
 
-export const _isNumber = num => typeof num === 'number'
+export const _isNumber = num => typeof num === 'number' && !isNaN(num)
 
 export const _isObject = obj => typeof obj === 'object'
 


### PR DESCRIPTION
In #7 only dates are sorted correctly, because the comparison function gets the impression that everything is a date. This PR fixes the problem for strings but I have not done testing for numbers or dates so it may be incomplete.