### PR TITLE
Lookup by column 

### DIFF
--- a/src/TableSortable/index.js
+++ b/src/TableSortable/index.js
@@ -154,10 +154,10 @@ class TableSortable {
             'second argument must be array of keys'
         )
         if (!cols.length) {
-            cols = columns
+            cols = Utils._keys(cols)
         }
         this._pagination.currentPage = 0
-        this._dataset.lookUp(val, Utils._keys(cols))
+        this._dataset.lookUp(val, cols)
         this.debounceUpdateTable()
     }
 


### PR DESCRIPTION
Fixed bug.
It was not possible to use columns you want to search as a second argument in function lookUp() because next you are passing the keys of array you get to this function: `this._dataset.lookUp(val, Utils._keys(cols))`
But the second argument of function lookUp() is an array of key and the keys of array_of_keys are always numbers 0,1,2,etc
